### PR TITLE
Documentation Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Primary configuration parameters:
 
 - `[DRAIN]/sim_th` - similarity threshold. if percentage of similar tokens for a log message is below this number, a new
   log cluster will be created (default 0.4)
-- `[DRAIN]/depth` - max depth levels of log clusters. Minimum is 2. (default 4)
+- `[DRAIN]/depth` - max depth levels of log clusters. Minimum is 3. (default 4)
 - `[DRAIN]/max_children` - max number of children of an internal node (default 100)
 - `[DRAIN]/max_clusters` - max number of tracked clusters (unlimited by default). When this number is reached, model
   starts replacing old clusters with a new ones according to the LRU cache eviction policy.

--- a/drain3/drain.py
+++ b/drain3/drain.py
@@ -62,7 +62,7 @@ class DrainBase:
         """
         Create a new Drain instance.
 
-        :param depth: max depth levels of log clusters. Minimum is 2.
+        :param depth: max depth levels of log clusters. Minimum is 3.
             For example, for depth==4, Root is considered depth level 1.
             Token count is considered depth level 2.
             First log token is considered depth level 3.


### PR DESCRIPTION
- Minimum depth required for Drain is 3 however documentation says 2.

Corresponding code checks in DrainBase
```
        if depth < 3:
            raise ValueError("depth argument must be at least 3")
```
